### PR TITLE
Change dependency to anycable-rails-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- Changed **anycable-rails** dependency to **anycable-rails-core**
+- Changed **anycable-rails** dependency to **anycable-rails-core**.
 - **Ruby 2.7+** is required.
 
 ## 0.1.0 (2020-09-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Changed **anycable-rails** dependency to **anycable-rails-core**
 - **Ruby 2.7+** is required.
 
 ## 0.1.0 (2020-09-23)

--- a/anycable-rails-jwt.gemspec
+++ b/anycable-rails-jwt.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.7"
 
-  s.add_dependency "anycable-rails", "~> 1.1"
+  s.add_dependency "anycable-rails-core", "~> 1.1"
   s.add_dependency "jwt", "~> 2.2"
 
   s.add_development_dependency "bundler", ">= 1.15"


### PR DESCRIPTION
## What is the purpose of this pull request?

RPC isn't needed for JWT authentication so the **anycable-rails** dependency can be replaced with **anycable-rails-core**.

## What changes did you make? (overview)

Changed the dependency in the gemspec file.

## Is there anything you'd like reviewers to focus on?

No.

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
